### PR TITLE
bugfix/fix-IE-edge-issue

### DIFF
--- a/vendor/styles/ember-plupload.css
+++ b/vendor/styles/ember-plupload.css
@@ -1,3 +1,7 @@
 .pl-uploader {
   position: relative;
 }
+
+.pl-uploader input[type="file"] {
+  z-index: 9999;
+}


### PR DESCRIPTION
### Issue 

On IE edge, the `input` tag is frequently not getting triggered on click, because it is hidden under the overlay. Looks like this is being caused by improper z-axis stacking of the DOM nodes on Edge. The input field should ideally be over the div but is under it on Edge. 

### Resolution

I have added a z-index to the `input` tag. Now it shows up above the other layer, and triggers properly